### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+daptup (0.12.8) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Thu, 13 Sep 2018 16:19:00 +0100
+
 daptup (0.12.7) unstable; urgency=low
 
   * New option 'DAPTUP_HOOK_ENABLED'. (Closes: #733960)

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: extra
 Maintainer: Eugene V. Lyubimkin <jackyf@debian.org>
 Build-Depends-Indep: debhelper (>= 9), gettext
 Standards-Version: 3.9.6
-Vcs-Git: git://github.com/jackyf/daptup.git
-Vcs-Browser: http://github.com/jackyf/daptup
+Vcs-Git: https://github.com/jackyf/daptup.git
+Vcs-Browser: https://github.com/jackyf/daptup
 Homepage: http://sourceforge.net/projects/daptup
 
 Package: daptup


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
